### PR TITLE
Add a OneOf token, for generally picking objects out of a list by an associated string.

### DIFF
--- a/muss/test/parser/test_oneof.py
+++ b/muss/test/parser/test_oneof.py
@@ -1,0 +1,37 @@
+import pyparsing as pyp
+
+from muss import parser
+from muss.test.parser import parser_tools
+
+
+class OneOfTestCase(parser_tools.ParserTestCase):
+    def test_easy(self):
+        result = object()
+        self.assert_parse(parser.OneOf({"foo": result, "bar": object()}), "foo",
+                          result)
+
+    def test_partial(self):
+        result = object()
+        token = parser.OneOf({"foo": result, "bar": object()}, exact=False)
+        self.assert_parse(token, "f", result)
+
+    def test_partial_ambiguous(self):
+        token = parser.OneOf({"bar": object(), "baz": object()}, exact=False)
+        self.assertRaises(parser.AmbiguityError, token.parseString, "b",
+                          parseAll=True)
+
+    def test_partial_but_exact(self):
+        token = parser.OneOf({"foo": object(), "bar": object()}, exact=True)
+        self.assertRaises(parser.NotFoundError, token.parseString, "f",
+                          parseAll=True)
+
+    def test_notfound(self):
+        self.assertRaises(parser.NotFoundError,
+                          parser.OneOf({"foo": object()}).parseString, "bar",
+                          parseAll=True)
+
+    def test_pattern(self):
+        result = object()
+        token = parser.OneOf({"1": object(), "12": result, "12x": object()},
+                             pattern=pyp.Word(pyp.nums))
+        self.assertEqual(token.parseString("12x", parseAll=False)[0], result)

--- a/muss/test/parser/test_oneof.py
+++ b/muss/test/parser/test_oneof.py
@@ -20,6 +20,11 @@ class OneOfTestCase(parser_tools.ParserTestCase):
         self.assertRaises(parser.AmbiguityError, token.parseString, "b",
                           parseAll=True)
 
+    def test_prefer_full(self):
+        result = object()
+        token = parser.OneOf({"foo": result, "foobar": object()}, exact=False)
+        self.assert_parse(token, "foo", result)
+
     def test_partial_but_exact(self):
         token = parser.OneOf({"foo": object(), "bar": object()}, exact=True)
         self.assertRaises(parser.NotFoundError, token.parseString, "f",

--- a/muss/test/parser/test_oneof.py
+++ b/muss/test/parser/test_oneof.py
@@ -7,36 +7,41 @@ from muss.test.parser import parser_tools
 class OneOfTestCase(parser_tools.ParserTestCase):
     def test_easy(self):
         result = object()
-        self.assert_parse(parser.OneOf({"foo": result, "bar": object()}), "foo",
-                          result)
+        token = parser.OneOf("test", {"foo": result, "bar": object()})
+        self.assert_parse(token, "foo", result)
 
     def test_partial(self):
         result = object()
-        token = parser.OneOf({"foo": result, "bar": object()}, exact=False)
+        token = parser.OneOf("test", {"foo": result, "bar": object()},
+                             exact=False)
         self.assert_parse(token, "f", result)
 
     def test_partial_ambiguous(self):
-        token = parser.OneOf({"bar": object(), "baz": object()}, exact=False)
+        token = parser.OneOf("test", {"bar": object(), "baz": object()},
+                             exact=False)
         self.assertRaises(parser.AmbiguityError, token.parseString, "b",
                           parseAll=True)
 
     def test_prefer_full(self):
         result = object()
-        token = parser.OneOf({"foo": result, "foobar": object()}, exact=False)
+        token = parser.OneOf("test", {"foo": result, "foobar": object()},
+                             exact=False)
         self.assert_parse(token, "foo", result)
 
     def test_partial_but_exact(self):
-        token = parser.OneOf({"foo": object(), "bar": object()}, exact=True)
+        token = parser.OneOf("test", {"foo": object(), "bar": object()},
+                             exact=True)
         self.assertRaises(parser.NotFoundError, token.parseString, "f",
                           parseAll=True)
 
     def test_notfound(self):
         self.assertRaises(parser.NotFoundError,
-                          parser.OneOf({"foo": object()}).parseString, "bar",
-                          parseAll=True)
+                          parser.OneOf("test", {"foo": object()}).parseString,
+                          "bar", parseAll=True)
 
     def test_pattern(self):
         result = object()
-        token = parser.OneOf({"1": object(), "12": result, "12x": object()},
+        token = parser.OneOf("test",
+                             {"1": object(), "12": result, "12x": object()},
                              pattern=pyp.Word(pyp.nums))
         self.assertEqual(token.parseString("12x", parseAll=False)[0], result)


### PR DESCRIPTION
Have a look at this -- I'm still only so-so on the parser. In general I think we can refactor things like ObjectIn on top of this (where the dict is `{object.name: object for object in whatever}`), but also it's the clean way to handle things like a command whose arg is "one of the channels you're in."