### PR TITLE
Ambiguous exits

### DIFF
--- a/muss/commands/test.py
+++ b/muss/commands/test.py
@@ -110,3 +110,16 @@ class Ptest(parser.Command):
 
         d = handler.prompt(player, "Enter text")
         d.addCallback(handle_response)
+
+class ZZZ(parser.Command):
+    name = "threezeds"
+    nospace_name = "zzz"
+    usage = ["zzz <text>", "zzz<text>"]
+    help_text = "Does nothing useful whatsoever."
+
+    @classmethod
+    def args(cls, player):
+        return parser.Text("text")
+
+    def execute(self, player, args):
+        player.send("Spaaaaaaaaaaaaaace. ({}).".format(args["text"]))

--- a/muss/handler.py
+++ b/muss/handler.py
@@ -122,9 +122,7 @@ class NormalMode(Mode):
                         return
                     # At this point there can only be one nospace command.
                     # Let it fall all the way through to execution.
-                except parser.NotFoundError:
-                    # Not the one we just caught; we're passing the exception
-                    # we just handled to the block below.
+                except parser.NotFoundError as _:
                     raise e
 
         except parser.NotFoundError as e:

--- a/muss/handler.py
+++ b/muss/handler.py
@@ -103,8 +103,8 @@ class NormalMode(Mode):
                                                 nospace_matches + [matched])
                 else:
                     name, command = parse_result["command"]
-            except parser.MatchError as e:
-                # Is there an exit here by that name?
+            except parser.NotFoundError as e:
+                # No commands match, what about exits?
                 exits = [(exit.name, exit) for exit in
                          db.find_all(lambda x: x.type == 'exit' and
                                                x.location == player.location)]
@@ -120,7 +120,9 @@ class NormalMode(Mode):
                     # Don't jump to the parse checks, just give up.
                     player.send(f.verbose())
                     return
-                except parser.MatchError:
+                except parser.NotFoundError:
+                    # Not the one we just caught; we're passing the exception
+                    # we just handled to the block below.
                     raise e
 
         except parser.NotFoundError as e:

--- a/muss/handler.py
+++ b/muss/handler.py
@@ -115,6 +115,11 @@ class NormalMode(Mode):
                     from commands.world import Go
                     Go().execute(player, {"exit": exit})
                     return
+                except parser.AmbiguityError as f:
+                    # Multiple exits match and no commands do.
+                    # Don't jump to the parse checks, just give up.
+                    player.send(f.verbose())
+                    return
                 except parser.MatchError:
                     raise e
 

--- a/muss/handler.py
+++ b/muss/handler.py
@@ -116,10 +116,12 @@ class NormalMode(Mode):
                     Go().execute(player, {"exit": exit})
                     return
                 except parser.AmbiguityError as f:
-                    # Multiple exits match and no commands do.
-                    # Don't jump to the parse checks, just give up.
-                    player.send(f.verbose())
-                    return
+                    # Multiple exits match and no full commands do.
+                    if not nospace_matches:
+                        player.send(f.verbose())
+                        return
+                    # At this point there can only be one nospace command.
+                    # Let it fall all the way through to execution.
                 except parser.NotFoundError:
                     # Not the one we just caught; we're passing the exception
                     # we just handled to the block below.

--- a/muss/handler.py
+++ b/muss/handler.py
@@ -111,10 +111,10 @@ class NormalMode(Mode):
                 try:
                     pattern = parser.OneOf(exits)("exit").setName("exit")
                     parse_result = pattern.parseString(first, parseAll=True)
-                    exit = parse_result["exit"]
-                    from commands.world import Go
-                    Go().execute(player, {"exit": exit})
-                    return
+                    # OneOf(exits) parsed, so exactly one exit matches.
+                    if not nospace_matches:
+                        command = commands.world.Go
+                        arguments = first
                 except parser.AmbiguityError as f:
                     # Multiple exits match and no full commands do.
                     if not nospace_matches:

--- a/muss/test/test_handler.py
+++ b/muss/test/test_handler.py
@@ -76,7 +76,7 @@ class HandlerTestCase(common_tools.MUSSTestCase):
             self.exit_jo = db.Exit("joust", self.lobby, self.foyer)
         for obj in self.foyer, self.exit_ju, self.exit_jo:
             db.store(obj)
-        self.assert_response("j", "Which way do you want to go? (joust, jump)")
+        self.assert_response("j", "Which exit do you mean? (joust, jump)")
 
     def test_re(self):
         self.assert_response("re", startswith="Which command do you mean")

--- a/muss/test/test_handler.py
+++ b/muss/test/test_handler.py
@@ -58,7 +58,6 @@ class HandlerTestCase(common_tools.MUSSTestCase):
         self.assertIsInstance(self.player.mode, handler.LineCaptureMode)
         self.assert_response("stuff and things", "stuff and things")
 
-
     def test_exit_invocation(self):
         with locks.authority_of(locks.SYSTEM):
             self.foyer = db.Room("foyer")
@@ -68,6 +67,15 @@ class HandlerTestCase(common_tools.MUSSTestCase):
         self.assertEqual(self.player.location, self.lobby)
         self.player.send_line("exit")
         self.assertEqual(self.player.location, self.foyer)
+
+    def test_exit_permissions(self):
+        with locks.authority_of(locks.SYSTEM):
+            self.foyer = db.Room("foyer")
+            self.exit = db.Exit("exit", self.lobby, self.foyer)
+            self.exit.locks.go = locks.Fail()
+        db.store(self.foyer)
+        db.store(self.exit)
+        self.assert_response("exit", "You can't go through exit.")
 
     def test_ambiguous_exit(self):
         with locks.authority_of(locks.SYSTEM):

--- a/muss/test/test_handler.py
+++ b/muss/test/test_handler.py
@@ -78,5 +78,21 @@ class HandlerTestCase(common_tools.MUSSTestCase):
             db.store(obj)
         self.assert_response("j", "Which exit do you mean? (joust, jump)")
 
+    def test_many_exits_and_commands(self):
+        with locks.authority_of(locks.SYSTEM):
+            self.exit_s1 = db.Exit("s1", self.lobby, self.lobby)
+            self.exit_s2 = db.Exit("s2", self.lobby, self.lobby)
+        db.store(self.exit_s1)
+        db.store(self.exit_s2)
+        self.assert_response("s", startswith="Which command do you mean")
+
+    def test_many_exits_one_command(self):
+        with locks.authority_of(locks.SYSTEM):
+            self.exit_h1 = db.Exit("h1", self.lobby, self.lobby)
+            self.exit_h2 = db.Exit("h2", self.lobby, self.lobby)
+        db.store(self.exit_h1)
+        db.store(self.exit_h2)
+        self.assert_response("h", startswith="Available commands:")
+
     def test_re(self):
         self.assert_response("re", startswith="Which command do you mean")

--- a/muss/test/test_handler.py
+++ b/muss/test/test_handler.py
@@ -69,5 +69,14 @@ class HandlerTestCase(common_tools.MUSSTestCase):
         self.player.send_line("exit")
         self.assertEqual(self.player.location, self.foyer)
 
+    def test_ambiguous_exit(self):
+        with locks.authority_of(locks.SYSTEM):
+            self.foyer = db.Room("foyer")
+            self.exit_ju = db.Exit("jump", self.lobby, self.foyer)
+            self.exit_jo = db.Exit("joust", self.lobby, self.foyer)
+        for obj in self.foyer, self.exit_ju, self.exit_jo:
+            db.store(obj)
+        self.assert_response("j", "Which way do you want to go? (joust, jump)")
+
     def test_re(self):
         self.assert_response("re", startswith="Which command do you mean")

--- a/muss/test/test_handler.py
+++ b/muss/test/test_handler.py
@@ -102,6 +102,14 @@ class HandlerTestCase(common_tools.MUSSTestCase):
         db.store(self.exit_h2)
         self.assert_response("h", startswith="Available commands:")
 
+    def test_exit_nospace(self):
+        with locks.authority_of(locks.SYSTEM):
+            self.foyer = db.Room("foyer")
+            self.zzzfoo = db.Exit("zzzfoo", self.lobby, self.foyer)
+        db.store(self.foyer)
+        db.store(self.zzzfoo)
+        self.assert_response("zzzfoo", "Spaaaaaaaaaaaaaace. (foo).")
+
     def test_many_exits_one_nospace(self):
         with locks.authority_of(locks.SYSTEM):
             self.exit_zzza = db.Exit("zzza", self.lobby, self.lobby)

--- a/muss/test/test_handler.py
+++ b/muss/test/test_handler.py
@@ -94,5 +94,13 @@ class HandlerTestCase(common_tools.MUSSTestCase):
         db.store(self.exit_h2)
         self.assert_response("h", startswith="Available commands:")
 
+    def test_many_exits_one_nospace(self):
+        with locks.authority_of(locks.SYSTEM):
+            self.exit_zzza = db.Exit("zzza", self.lobby, self.lobby)
+            self.exit_zzzb = db.Exit("zzzb", self.lobby, self.lobby)
+        db.store(self.exit_zzza)
+        db.store(self.exit_zzzb)
+        self.assert_response("zzz foo", "Spaaaaaaaaaaaaaace. (foo).")
+
     def test_re(self):
         self.assert_response("re", startswith="Which command do you mean")


### PR DESCRIPTION
This is a relatively straightforward fix with only two real changes:

* Don't even bother checking for exit name matches when you already have command name matches (line 106 in the updated file, changing the MatchError trap to a NotFoundError trap).
* Within exit name parsing, handle AmbiguityErrors separately from NotFoundErrors. The current version passes both through to be handled by the following block, which is why we get the error message complained about in #132. Updated version only passes through NotFoundErrors. AmbiguityErrors are either handled separately, or (in the very specific case there was a nospace command already found) ignored.

Having fixed this I now want to refactor this whole block; it's gotten very complex through the addition of several features, and doesn't need to be. That's a PR for another day.